### PR TITLE
Allow client consumers to customize request init

### DIFF
--- a/demos/default/client/client.ts
+++ b/demos/default/client/client.ts
@@ -8,44 +8,52 @@ export class DefaultClient implements Client<DefaultData> {
     private readonly fetcher: Fetcher,
   ) {}
 
-  async get(key: string): Promise<DefaultData> {
+  async get(key: string, opts?: RequestInit): Promise<DefaultData> {
     const url = new URL(`${this.origin}/${key}`);
-    const res = await this.fetcher.fetch(url);
+    const res = await this.fetcher.fetch(url, opts);
     return await res.json() as DefaultData;
   }
 
-  async set(data: DefaultData) {
+  async set(data: DefaultData, opts?: RequestInit) {
     const res = await this.fetcher.fetch(this.origin, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),
+      ...opts,
     });
     return await res.text();
   }
 
-  async remove(key: string) {
+  async remove(key: string, opts?: RequestInit) {
     const url = new URL(`${this.origin}/${key}`);
-    const res = await this.fetcher.fetch(url, { method: "DELETE" });
+    const res = await this.fetcher.fetch(url, { method: "DELETE", ...opts });
     if (res.status !== 200) {
       throw new Error(await res.text());
     }
   }
 
-  async list(data?: Partial<DefaultData>): Promise<DefaultData[]> {
+  async list(
+    data?: Partial<DefaultData>,
+    opts?: RequestInit,
+  ): Promise<DefaultData[]> {
     const res = await this.fetcher.fetch(this.origin, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify(data),
+      ...opts,
     });
     return await res.json() as DefaultData[];
   }
 
-  async clear() {
-    const res = await this.fetcher.fetch(this.origin, { method: "DELETE" });
+  async clear(opts?: RequestInit) {
+    const res = await this.fetcher.fetch(this.origin, {
+      method: "DELETE",
+      ...opts,
+    });
     if (res.status !== 200) {
       throw new Error(await res.text());
     }


### PR DESCRIPTION
Allow developers to pass optional custom RequestInit props to each `Server` method.

Resolves #22.