### PR TITLE
Add CORS logic to serve API

### DIFF
--- a/demos/default/main.ts
+++ b/demos/default/main.ts
@@ -7,6 +7,9 @@ main();
 function main() {
   const flags = parse(Deno.args);
   const port = Number(flags.port || flags.p) || 8080;
+  const allowedOrigins = typeof flags.cors === "string"
+    ? String(flags.cors)
+    : flags.cors && "*";
 
-  serve({ port });
+  serve({ port, allowedOrigins });
 }

--- a/demos/default/main.ts
+++ b/demos/default/main.ts
@@ -7,9 +7,9 @@ main();
 function main() {
   const flags = parse(Deno.args);
   const port = Number(flags.port || flags.p) || 8080;
-  const allowedOrigins = typeof flags.cors === "string"
-    ? String(flags.cors)
-    : flags.cors && "*";
+  const allowedOrigins =
+    (typeof flags.cors === "string" ? String(flags.cors) : flags.cors && "*") ||
+    Deno.env.get("CORS");
 
   serve({ port, allowedOrigins });
 }

--- a/serve.ts
+++ b/serve.ts
@@ -9,6 +9,7 @@ import { DefaultHandler, DefaultServer } from "./http/default/mod.ts";
 
 export interface ServeInit<Data extends DefaultData> extends StdServeInit {
   storage?: Storer<string, Data>;
+  allowedOrigins?: string;
 }
 
 /**
@@ -49,10 +50,24 @@ export interface ServeInit<Data extends DefaultData> extends StdServeInit {
 export function serve<Data extends DefaultData>(
   {
     storage: s = new WebStorer((d: Data) => d[d.$key]),
+    allowedOrigins,
     ...o
   }: ServeInit<Data> = {},
 ): void {
   const p = new DefaultServer<Data>(s); // provider
   const h = new DefaultHandler(p);
-  stdServe(h.handle.bind(h), o);
+
+  // Apply CORS when allowedOrigins is defined
+  if (allowedOrigins) {
+    stdServe(async (req) => {
+      return applyCORS(await h.handle(req), allowedOrigins);
+    }, o);
+  } else {
+    stdServe(h.handle.bind(h), o);
+  }
+}
+
+function applyCORS(res: Response, accessControl: string): Response {
+  res.headers.set("Access-Control-Allow-Origin", accessControl);
+  return res;
 }


### PR DESCRIPTION
### Goal

Allow HTTP client consumers to run development servers with CORS enabled for the relevant domains.

Note: For compatibility with Deno Deploy, read this value from [environment variables](https://examples.deno.land/environment-variables) by default and override by CLI flag.

Resolve #24.